### PR TITLE
msgraw: don't ensure_ascii

### DIFF
--- a/dango/plugins/misc.py
+++ b/dango/plugins/misc.py
@@ -388,7 +388,7 @@ class Misc:
         raw = await ctx.bot.http.get_message(ctx.channel.id, msg_id)
 
         await ctx.send("```json\n{}```".format(
-            utils.clean_triple_backtick(json.dumps(raw, indent=2))))
+            utils.clean_triple_backtick(json.dumps(raw, indent=2, ensure_ascii=False))))
 
     @command()
     async def nostalgia(self, ctx, channel: discord.TextChannel=None, date: utils.convert_date=None):


### PR DESCRIPTION
Makes unicode emojis show up as unicode emojis, rather than e.g. \ud83d\udd34.

Non-printable characters, such as "zero width space", are still turned into their \u200b form.