### PR TITLE
clean_single_backtick: fallback to double

### DIFF
--- a/dango/plugins/common/utils.py
+++ b/dango/plugins/common/utils.py
@@ -85,7 +85,7 @@ def clean_invite_embed(line):
 def clean_single_backtick(line):
     """Clean string for insertion in single backtick code section."""
     if re.search('[^`]`[^`]', line) is not None:
-        raise ValueError("Cannot be cleaned")
+        return "`%s`" % clean_double_backtick(line)
     if (line[:2] == '``'):
         line = '\u200b' + line
     if (line[-1] == '`'):

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -74,15 +74,12 @@ class TestFormattingUtils(unittest.TestCase):
             ['`\u200b', '`'],
             ['\u200b``\u200b', '``'],
             ['\u200b`` ``\u200b', '`` ``'],
-            [' ``` ``\u200b', ' ``` ``']
+            [' ``` ``\u200b', ' ``` ``'],
+            ['`test `single backtick` on interior`', 'test `single backtick` on interior'],
         ]
 
         for sample in samples:
             self.assertEquals(sample[0], utils.clean_single_backtick(sample[1]))
-
-    def test_uncleanable_single_backtick(self):
-        with self.assertRaises(ValueError):
-            utils.clean_single_backtick('test `single backtick` on interior')
 
     def test_clean_triple_backtick(self):
         samples = [


### PR DESCRIPTION
Double backtick always is cleanable, so in the "uncleanable" case,
just use the double backtick instead.