### PR TITLE
msgraw: sort keys

### DIFF
--- a/dango/plugins/misc.py
+++ b/dango/plugins/misc.py
@@ -388,7 +388,8 @@ class Misc:
         raw = await ctx.bot.http.get_message(ctx.channel.id, msg_id)
 
         await ctx.send("```json\n{}```".format(
-            utils.clean_triple_backtick(json.dumps(raw, indent=2, ensure_ascii=False))))
+            utils.clean_triple_backtick(json.dumps(
+                raw, indent=2, ensure_ascii=False, sort_keys=True))))
 
     @command()
     async def nostalgia(self, ctx, channel: discord.TextChannel=None, date: utils.convert_date=None):


### PR DESCRIPTION
The key order isn't actually what discord gives us, since
it's parsed by the lib. Sort for consistency.