### PR TITLE
add clearer aliases for msgraw and msgsource

### DIFF
--- a/dango/plugins/misc.py
+++ b/dango/plugins/misc.py
@@ -461,7 +461,7 @@ class Misc:
             for c in text
         ))
 
-    @command()
+    @command(aliases=['msgsrc', 'msgtext'])
     async def msgsource(self, ctx, *, msg_id: int):
         """Show source for a message."""
         try:
@@ -471,7 +471,7 @@ class Misc:
         else:
             await ctx.send("```{}```".format(utils.clean_triple_backtick(msg.content)))
 
-    @command()
+    @command(aliases=['msgjson'])
     async def msgraw(self, ctx, *, msg_id: int):
         """Show raw JSON for a message."""
         raw = await ctx.bot.http.get_message(ctx.channel.id, msg_id)


### PR DESCRIPTION
both commands are kinda "raw message", so i added "msgjson" to be more clear
and in "msgsource", "msg" is abbreviated, but "source" is not, so it can be hard to figure out