### PR TITLE
stop ignoring bots

### DIFF
--- a/dango/core.py
+++ b/dango/core.py
@@ -119,6 +119,11 @@ class DangoBotBase(commands.bot.BotBase):
     def get_context(self, message):
         return super().get_context(message, cls=DangoContext)
 
+    async def process_commands(self, message):
+        """Overridden because the default process_commands ignores bots."""
+        ctx = await self.get_context(message)
+        await self.invoke(ctx)
+
     def add_cog(self, cls):
         """Tries to load a cog.
 


### PR DESCRIPTION
As of https://github.com/Rapptz/discord.py/commit/aa7c5c3ec1b2df6c95c39b149639ebca9aa68859 the default
behavior is to ignore bots, which was not the intention for dango.py.